### PR TITLE
V1.3 Create Autofill feature

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -23,6 +23,8 @@ import seedu.address.logic.ListElementPointer;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -37,6 +39,7 @@ public class CommandBox extends UiPart<Region> {
     private final Logger logger = LogsCenter.getLogger(CommandBox.class);
     private final Logic logic;
     private ListElementPointer historySnapshot;
+    private boolean canTab = false;
 
     @FXML
     private TextField commandTextField;
@@ -67,7 +70,7 @@ public class CommandBox extends UiPart<Region> {
             break;
         case TAB:
             keyEvent.consume();
-            checkCommand();
+            autofillCommand();
             break;
         case DELETE:
             keyEvent.consume();
@@ -82,23 +85,39 @@ public class CommandBox extends UiPart<Region> {
      * Sets {@code CommandBox}'s text field with input format and
      * if next field is present, it positions the caret to the next field.
      */
-    private void checkCommand() {
+    private void autofillCommand() {
         String input = commandTextField.getText();
+        int nextCaretPosition = -1;
+
         switch (input) {
         case AddCommand.COMMAND_WORD:
         case AddCommand.COMMAND_WORD_ALIAS:
             commandTextField.setText("add " + PREFIX_NAME + " " + PREFIX_PHONE + " " + PREFIX_EMAIL + " "
                     + PREFIX_ADDRESS + " " + PREFIX_PRICE + " " + PREFIX_SUBJECT + " " + PREFIX_LEVEL + " "
                     + PREFIX_STATUS + " " + PREFIX_ROLE);
+            canTab = true;
+            break;
+        case SelectCommand.COMMAND_WORD:
+        case SelectCommand.COMMAND_WORD_ALIAS:
+            commandTextField.setText(SelectCommand.COMMAND_WORD + " 1");
+            selectIndexToEdit();
+            canTab = false;
+            break;
+        case DeleteCommand.COMMAND_WORD:
+        case DeleteCommand.COMMAND_WORD_ALIAS:
+            commandTextField.setText(DeleteCommand.COMMAND_WORD + " 1");
+            selectIndexToEdit();
+            canTab = false;
             break;
         default:
             // no autofill
         }
 
-        int nextCaretPosition = findNextField();
-
-        if (nextCaretPosition != -1) {
-            commandTextField.positionCaret(nextCaretPosition);
+        if (canTab) {
+            nextCaretPosition = findNextField();
+            if (nextCaretPosition != -1) {
+                commandTextField.positionCaret(nextCaretPosition);
+            }
         }
     }
 
@@ -127,6 +146,18 @@ public class CommandBox extends UiPart<Region> {
         int nextFieldPosition = text.indexOf("/", caretPosition);
 
         return nextFieldPosition + 1;
+    }
+
+    /**
+     * Positions the caret to index position
+     * and selects the index to be edited.
+     */
+    private void selectIndexToEdit() {
+        String text = commandTextField.getText();
+        int indexPosition = text.indexOf("1") + 1;
+
+        commandTextField.positionCaret(indexPosition);
+        commandTextField.selectBackward();
     }
 
     /**

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -24,6 +24,7 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -88,14 +89,25 @@ public class CommandBox extends UiPart<Region> {
     private void autofillCommand() {
         String input = commandTextField.getText();
         int nextCaretPosition = -1;
+        boolean isFirstTime = false; // set this to check for edit command
 
+        // first time tab is pressed
         switch (input) {
         case AddCommand.COMMAND_WORD:
         case AddCommand.COMMAND_WORD_ALIAS:
-            commandTextField.setText("add " + PREFIX_NAME + " " + PREFIX_PHONE + " " + PREFIX_EMAIL + " "
-                    + PREFIX_ADDRESS + " " + PREFIX_PRICE + " " + PREFIX_SUBJECT + " " + PREFIX_LEVEL + " "
-                    + PREFIX_STATUS + " " + PREFIX_ROLE);
+            commandTextField.setText(AddCommand.COMMAND_WORD + " " + PREFIX_NAME + " " + PREFIX_PHONE + " "
+                    + PREFIX_EMAIL + " " + PREFIX_ADDRESS + " " + PREFIX_PRICE + " " + PREFIX_SUBJECT + " "
+                    + PREFIX_LEVEL + " " + PREFIX_STATUS + " " + PREFIX_ROLE);
             canTab = true;
+            break;
+        case EditCommand.COMMAND_WORD:
+        case EditCommand.COMMAND_WORD_ALIAS:
+            commandTextField.setText(EditCommand.COMMAND_WORD + " 1 " + PREFIX_NAME + " " + PREFIX_PHONE + " "
+                    + PREFIX_EMAIL + " " + PREFIX_ADDRESS + " " + PREFIX_PRICE + " " + PREFIX_SUBJECT + " "
+                    + PREFIX_LEVEL + " " + PREFIX_STATUS + " " + PREFIX_ROLE);
+            selectIndexToEdit();
+            canTab = false;
+            isFirstTime = true;
             break;
         case SelectCommand.COMMAND_WORD:
         case SelectCommand.COMMAND_WORD_ALIAS:
@@ -113,11 +125,15 @@ public class CommandBox extends UiPart<Region> {
             // no autofill
         }
 
+        // subsequent times tab is pressed
         if (canTab) {
             nextCaretPosition = findNextField();
             if (nextCaretPosition != -1) {
                 commandTextField.positionCaret(nextCaretPosition);
             }
+        }
+        if (isFirstTime) {
+            canTab = true;
         }
     }
 

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -69,6 +69,10 @@ public class CommandBox extends UiPart<Region> {
             keyEvent.consume();
             checkCommand();
             break;
+        case DELETE:
+            keyEvent.consume();
+            deletePreviousPrefix();
+            break;
         default:
             // let JavaFx handle the keypress
         }
@@ -76,19 +80,53 @@ public class CommandBox extends UiPart<Region> {
 
     /**
      * Sets {@code CommandBox}'s text field with input format and
-     * positions the caret to the end of the {@code text}.
+     * if next field is present, it positions the caret to the next field.
      */
     private void checkCommand() {
         String input = commandTextField.getText();
         switch (input) {
         case AddCommand.COMMAND_WORD:
         case AddCommand.COMMAND_WORD_ALIAS:
-            commandTextField.setText("add " + PREFIX_NAME + " " + PREFIX_PHONE + " " + PREFIX_EMAIL + " " +
-                    PREFIX_ADDRESS + " " + PREFIX_PRICE + " " + PREFIX_SUBJECT + " " + PREFIX_LEVEL + " " +
-                    PREFIX_STATUS + " " + PREFIX_ROLE);
+            commandTextField.setText("add " + PREFIX_NAME + " " + PREFIX_PHONE + " " + PREFIX_EMAIL + " "
+                    + PREFIX_ADDRESS + " " + PREFIX_PRICE + " " + PREFIX_SUBJECT + " " + PREFIX_LEVEL + " "
+                    + PREFIX_STATUS + " " + PREFIX_ROLE);
+            break;
+        default:
+            // no autofill
         }
 
-        commandTextField.positionCaret(commandTextField.getText().length());
+        int nextCaretPosition = findNextField();
+
+        if (nextCaretPosition != -1) {
+            commandTextField.positionCaret(nextCaretPosition);
+        }
+    }
+
+    /**
+     * Deletes the previous prefix from current caret position and
+     * if next field is present, it positions the caret to the next field.
+     */
+    private void deletePreviousPrefix() {
+        String text = commandTextField.getText();
+        int caretPosition = commandTextField.getCaretPosition();
+        int deleteStart = text.lastIndexOf(" ", caretPosition - 1);
+
+        if (deleteStart != -1) {
+            commandTextField.deleteText(deleteStart, caretPosition);
+            commandTextField.positionCaret(findNextField());
+        }
+    }
+
+    /**
+     * Finds the next input field from current caret position and
+     * if next field is present, it positions the caret to the next field.
+     */
+    private int findNextField() {
+        String text = commandTextField.getText();
+        int caretPosition = commandTextField.getCaretPosition();
+        int nextFieldPosition = text.indexOf("/", caretPosition);
+
+        return nextFieldPosition + 1;
     }
 
     /**

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -48,10 +48,13 @@ public class CommandBox extends UiPart<Region> {
             // As up and down buttons will alter the position of the caret,
             // consuming it causes the caret's position to remain unchanged
             keyEvent.consume();
-
             navigateToPreviousInput();
             break;
         case DOWN:
+            keyEvent.consume();
+            navigateToNextInput();
+            break;
+        case TAB:
             keyEvent.consume();
             navigateToNextInput();
             break;

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,5 +1,15 @@
 package seedu.address.ui;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LEVEL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT;
+
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -11,6 +21,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.ui.NewResultAvailableEvent;
 import seedu.address.logic.ListElementPointer;
 import seedu.address.logic.Logic;
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -56,11 +67,28 @@ public class CommandBox extends UiPart<Region> {
             break;
         case TAB:
             keyEvent.consume();
-            navigateToNextInput();
+            checkCommand();
             break;
         default:
             // let JavaFx handle the keypress
         }
+    }
+
+    /**
+     * Sets {@code CommandBox}'s text field with input format and
+     * positions the caret to the end of the {@code text}.
+     */
+    private void checkCommand() {
+        String input = commandTextField.getText();
+        switch (input) {
+        case AddCommand.COMMAND_WORD:
+        case AddCommand.COMMAND_WORD_ALIAS:
+            commandTextField.setText("add " + PREFIX_NAME + " " + PREFIX_PHONE + " " + PREFIX_EMAIL + " " +
+                    PREFIX_ADDRESS + " " + PREFIX_PRICE + " " + PREFIX_SUBJECT + " " + PREFIX_LEVEL + " " +
+                    PREFIX_STATUS + " " + PREFIX_ROLE);
+        }
+
+        commandTextField.positionCaret(commandTextField.getText().length());
     }
 
     /**

--- a/src/test/java/guitests/guihandles/CommandBoxHandle.java
+++ b/src/test/java/guitests/guihandles/CommandBoxHandle.java
@@ -24,6 +24,19 @@ public class CommandBoxHandle extends NodeHandle<TextField> {
     }
 
     /**
+     * Inputs text in the command box.
+     */
+    public void setInput(String input) {
+        click();
+        guiRobot.interact(() -> getRootNode().setText(input));
+        /* if (getRootNode().getCaretPosition() == 0) {
+            guiRobot.interact(() -> getRootNode().setText(input));
+        } else {
+            guiRobot.interact(() -> getRootNode().insertText(getRootNode().getCaretPosition(), input));
+        } */
+    }
+
+    /**
      * Enters the given command in the Command Box and presses enter.
      * @return true if the command succeeded, false otherwise.
      */

--- a/src/test/java/seedu/address/ui/CommandBoxTest.java
+++ b/src/test/java/seedu/address/ui/CommandBoxTest.java
@@ -163,14 +163,12 @@ public class CommandBoxTest extends GuiUnitTest {
         commandBoxHandle.setInput("add");
         guiRobot.push(KeyCode.TAB);
         String actualOutput = commandBoxHandle.getInput();
-
         assertEquals(expectedOutput, actualOutput);
 
         // checks for add command word alias
         commandBoxHandle.setInput("a");
         guiRobot.push(KeyCode.TAB);
         actualOutput = commandBoxHandle.getInput();
-        
         assertEquals(expectedOutput, actualOutput);
 
         // checks if tab works correctly
@@ -188,14 +186,12 @@ public class CommandBoxTest extends GuiUnitTest {
         commandBoxHandle.setInput("select");
         guiRobot.push(KeyCode.TAB);
         String actualOutput = commandBoxHandle.getInput();
-
         assertEquals(expectedOutput, actualOutput);
 
         // checks for select command word alias
         commandBoxHandle.setInput("s");
         guiRobot.push(KeyCode.TAB);
         actualOutput = commandBoxHandle.getInput();
-
         assertEquals(expectedOutput, actualOutput);
     }
 
@@ -207,14 +203,12 @@ public class CommandBoxTest extends GuiUnitTest {
         commandBoxHandle.setInput("delete");
         guiRobot.push(KeyCode.TAB);
         String actualOutput = commandBoxHandle.getInput();
-
         assertEquals(expectedOutput, actualOutput);
 
         // checks for delete command word alias
         commandBoxHandle.setInput("d");
         guiRobot.push(KeyCode.TAB);
         actualOutput = commandBoxHandle.getInput();
-
         assertEquals(expectedOutput, actualOutput);
     }
 
@@ -226,14 +220,12 @@ public class CommandBoxTest extends GuiUnitTest {
         commandBoxHandle.setInput("edit");
         guiRobot.push(KeyCode.TAB);
         String actualOutput = commandBoxHandle.getInput();
-
         assertEquals(expectedOutput, actualOutput);
 
         // checks for edit command word alias
         commandBoxHandle.setInput("e");
         guiRobot.push(KeyCode.TAB);
         actualOutput = commandBoxHandle.getInput();
-
         assertEquals(expectedOutput, actualOutput);
     }
 

--- a/src/test/java/seedu/address/ui/CommandBoxTest.java
+++ b/src/test/java/seedu/address/ui/CommandBoxTest.java
@@ -179,6 +179,19 @@ public class CommandBoxTest extends GuiUnitTest {
     }
 
     @Test
+    public void handleKeyPress_addCommandPressDelete_removePreviousPrefix() {
+        String expectedOutput = "add p/ e/ a/ $/ sub/ lvl/ stat/ r/";
+
+        // checks for add command word
+        commandBoxHandle.setInput("add");
+        guiRobot.push(KeyCode.TAB);
+        guiRobot.push(KeyCode.DELETE);
+
+        String actualOutput = commandBoxHandle.getInput();
+        assertEquals(expectedOutput, actualOutput);
+    }
+
+    @Test
     public void handleKeyPress_selectCommandPressTab_autofill() {
         String expectedOutput = "select 1";
 

--- a/src/test/java/seedu/address/ui/CommandBoxTest.java
+++ b/src/test/java/seedu/address/ui/CommandBoxTest.java
@@ -154,4 +154,112 @@ public class CommandBoxTest extends GuiUnitTest {
         guiRobot.push(keycode);
         assertEquals(expectedCommand, commandBoxHandle.getInput());
     }
+
+    @Test
+    public void handleKeyPress_addCommandPressTab_autofill() {
+        String expectedOutput = "add n/ p/ e/ a/ $/ sub/ lvl/ stat/ r/";
+
+        // checks for add command word
+        commandBoxHandle.setInput("add");
+        guiRobot.push(KeyCode.TAB);
+        String actualOutput = commandBoxHandle.getInput();
+
+        assertEquals(expectedOutput, actualOutput);
+
+        // checks for add command word alias
+        commandBoxHandle.setInput("a");
+        guiRobot.push(KeyCode.TAB);
+        actualOutput = commandBoxHandle.getInput();
+        
+        assertEquals(expectedOutput, actualOutput);
+
+        // checks if tab works correctly
+        /*expectedOutput = "add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 $/50"
+                + " sub/Math lvl/Lower Sec stat/Not Matched r/Student";
+        actualOutput = enterPersonDetails();
+        assertEquals(expectedOutput, actualOutput);*/
+    }
+
+    @Test
+    public void handleKeyPress_selectCommandPressTab_autofill() {
+        String expectedOutput = "select 1";
+
+        // checks for select command word
+        commandBoxHandle.setInput("select");
+        guiRobot.push(KeyCode.TAB);
+        String actualOutput = commandBoxHandle.getInput();
+
+        assertEquals(expectedOutput, actualOutput);
+
+        // checks for select command word alias
+        commandBoxHandle.setInput("s");
+        guiRobot.push(KeyCode.TAB);
+        actualOutput = commandBoxHandle.getInput();
+
+        assertEquals(expectedOutput, actualOutput);
+    }
+
+    @Test
+    public void handleKeyPress_deleteCommandPressTab_autofill() {
+        String expectedOutput = "delete 1";
+
+        // checks for delete command word
+        commandBoxHandle.setInput("delete");
+        guiRobot.push(KeyCode.TAB);
+        String actualOutput = commandBoxHandle.getInput();
+
+        assertEquals(expectedOutput, actualOutput);
+
+        // checks for delete command word alias
+        commandBoxHandle.setInput("d");
+        guiRobot.push(KeyCode.TAB);
+        actualOutput = commandBoxHandle.getInput();
+
+        assertEquals(expectedOutput, actualOutput);
+    }
+
+    @Test
+    public void handleKeyPress_editCommandPressTab_autofill() {
+        String expectedOutput = "edit 1 n/ p/ e/ a/ $/ sub/ lvl/ stat/ r/";
+
+        // checks for edit command word
+        commandBoxHandle.setInput("edit");
+        guiRobot.push(KeyCode.TAB);
+        String actualOutput = commandBoxHandle.getInput();
+
+        assertEquals(expectedOutput, actualOutput);
+
+        // checks for edit command word alias
+        commandBoxHandle.setInput("e");
+        guiRobot.push(KeyCode.TAB);
+        actualOutput = commandBoxHandle.getInput();
+
+        assertEquals(expectedOutput, actualOutput);
+    }
+
+    /**
+     * Enters Person details using GUI robot
+     * @return String entered by GUI robot
+     */
+    private String enterPersonDetails() {
+        commandBoxHandle.setInput("John Doe");
+        guiRobot.push(KeyCode.TAB);
+        commandBoxHandle.setInput("98765432");
+        guiRobot.push(KeyCode.TAB);
+        commandBoxHandle.setInput("johnd@example.com");
+        guiRobot.push(KeyCode.TAB);
+        commandBoxHandle.setInput("311, Clementi Ave 2, #02-25");
+        guiRobot.push(KeyCode.TAB);
+        commandBoxHandle.setInput("50");
+        guiRobot.push(KeyCode.TAB);
+        commandBoxHandle.setInput("Math");
+        guiRobot.push(KeyCode.TAB);
+        commandBoxHandle.setInput("Lower Sec");
+        guiRobot.push(KeyCode.TAB);
+        commandBoxHandle.setInput("Not Matched");
+        guiRobot.push(KeyCode.TAB);
+        commandBoxHandle.setInput("Student");
+
+        return commandBoxHandle.getInput();
+    }
 }


### PR DESCRIPTION
Only add, edit, select, delete have autofill feature.

1.  After typing the command word or its alias, press 'TAB' to autofill the command and further presses on 'TAB' will change the caret position to the next field.

2. Press 'DELETE' to remove a particular prefix from the command input